### PR TITLE
Rename 433 MHz transmitter

### DIFF
--- a/docs/diy/assembling.md
+++ b/docs/diy/assembling.md
@@ -4,9 +4,9 @@ This guide mainly focuses on the parts listed in the [Hardware Buy guide](../qui
 ## Requirements
 
 + ESP-32
-+ 433 MHz antenna for micro-controllers
++ 433 MHz transmitter
 + Soldering station
-+ Optionally some spare cables if needed for the antenna to be wired up
++ Hookup wire (Optional depending if the pins line up)
 
 ## What/Where to buy?
 
@@ -14,4 +14,4 @@ See the [Hardware Buy guide here](../quickstart/buying-guide.md). For the board/
 
 ## Figuring out the PINs
 
-TODO
+Any digital output pin on your micro-controller should work for outputting the signal for the transmitter, however the default is often close to the positive and ground pins on the controller. See the [boards](../hardware/boards/index.md) section dedicated to the micro-controller your are using to decide which pin to use.

--- a/docs/diy/assembling.md
+++ b/docs/diy/assembling.md
@@ -10,7 +10,7 @@ This guide mainly focuses on the parts listed in the [Hardware Buy guide](../qui
 
 ## What/Where to buy?
 
-See the [Hardware Buy guide here](../quickstart/buying-guide.md). For the board/ESP-32 assembly you need the ESP-32 and a 433 MHz antenna.
+See the [Hardware Buy guide here](../quickstart/buying-guide.md). For the board/ESP-32 assembly you need the ESP-32 and a 433 MHz transmitter.
 
 ## Figuring out the PINs
 

--- a/docs/hardware/boards/index.md
+++ b/docs/hardware/boards/index.md
@@ -8,7 +8,7 @@
 |Icon|Meaning|
 |-|-|
 | :white_check_mark: | Fully compatible |
-| :warning: | Partial compatability |
+| :warning: | Partial compatibility |
 | :x: | Not compatible |
 | :hammer_and_wrench: | In progress |
 | :grey_question: | Unknown |
@@ -51,7 +51,7 @@ We do our best to give these contributors sufficient time to test new firmware d
 | Board | Variant | Labels | Maintainer(s) |
 |-|-|-|-|
 | [Wemos Lolin S2 Mini](wemos/lolin-s2-mini.md) | N4R2 (All) | | [:airplane: Red Mushie](https://github.com/redmushie) |
-| [DFRobot Firebeetle ESP32-E](dfr-firebeetle/dfr-firebeetle.md) | ESP32-E (All) | | [:airplane: LostQuasar](https://github.com/LostQuasar) |
+| [DFRobot FireBeetle ESP32-E](dfr-firebeetle/dfr-firebeetle.md) | ESP32-E (All) | | [:airplane: LostQuasar](https://github.com/LostQuasar) |
 
 ## Not maintained
 

--- a/docs/hardware/boards/openshock/core-v1.md
+++ b/docs/hardware/boards/openshock/core-v1.md
@@ -19,7 +19,7 @@ Designed by [nullstalgia](../../../vendors/hardware/nullstalgia.md)
 
 - Espressif ESP32-S3-WROOM-1-N8 (8MB Flash, no PSRAM)
 - USB-C Connection to integrated ESP32-S3 USB (no UART adapter)
-- On-board 433MHz RF Transmitter
+- On-board 433 MHz Transmitter
 - RGB and Status LEDs
 - On-board Emergency Stop Button, plus 3.5mm extension port (for foot pedals)
 

--- a/docs/hardware/boards/pishock/2021q3-lite.md
+++ b/docs/hardware/boards/pishock/2021q3-lite.md
@@ -19,7 +19,7 @@ tags:
 ## Specifications
 
 - Board is [Wemos D1 Mini ESP32](../wemos/d1-mini-esp32.md)
-- Simple [433MHz radio board](../../radio/index.md)
+- Simple [433 MHz transmitter](../../transmitter/index.md)
 
 ## Pinout
 

--- a/docs/hardware/boards/pishock/2023-pishock.md
+++ b/docs/hardware/boards/pishock/2023-pishock.md
@@ -20,7 +20,7 @@ First seen in the wild on `2023-09-19`.
 ## Specifications
 
 - Espressif ESP32-WROOM-32D
-- On-board radio chip
+- On-board 433 MHz transmitter
 
 ## Pinout
 

--- a/docs/hardware/transmitter/index.md
+++ b/docs/hardware/transmitter/index.md
@@ -1,15 +1,15 @@
 ---
 tags:
     - hardware
-    - radio
+    - transmitter
     - 433mhz
 ---
 
-# Radio
+# Transmitter
 
 Any 433 MHz transmitter that is compatible with ASK / OOK should work with OpenShock. Below are transmitters that have been tested to work.
 
 !!! warning "Ask for transmitters"
     This vendor sells the transmitter and receiver **as a pair**. If you would like 2 transmitters instead. Ask the seller for **only transmitters**.
 
-- :globe_with_meridians: International -- [AliExpress](https://aliexpress.com/item/32820610184.html)
+- :globe_with_meridians: International: [AliExpress](https://aliexpress.com/item/32820610184.html)

--- a/docs/quickstart/buying-guide.md
+++ b/docs/quickstart/buying-guide.md
@@ -2,37 +2,31 @@
 # Buying guide
 
 !!! example "Still brewing!"
+    Sorry, we haven't *quite* finished this article yet. **In the meantime, feel free to hit us up on [Discord](https://discord.gg/OpenShock) if you have any trouble.**
 
-    Sorry, we haven't _quite_ finished this article yet. **In the meantime, feel free to hit us up on [Discord](https://discord.gg/AHcCbXbEcF) if you have any trouble.**
-
-!!! tip "Prebuilts available"
-
-    Not interested in building your own OpenShock Bridge? Head over to the [Hardware vendors](../vendors/hardware/index.md).
+!!! tip "pre-built options available"
+    Not interested in building your own OpenShock hub? Head over to the [Hardware vendors](../vendors/hardware/index.md).
 
 These are the **recommendations** of the OpenShock maintainers. This list is **not** exhaustive. For a much more *wiki-style* information base, head to the [Hardware](../hardware/boards/index.md) section.
-
-
 
 ## Board
 
 ### Existing hardware
 
 !!! info "Existing hardware"
-
-    If you already own a Pishock or another ESP32, please check the [Boards compatability list](../hardware/boards/index.md).
+    If you already own a PiShock or another ESP32, please check the [Boards compatibility list](../hardware/boards/index.md).
 
 ### ESP32-S3
 
 We recommend the `ESP32-S3` chip, specifically the `N16R8` variant for its 16 MiB of flash. The [Wemos Lolin S3](../hardware/boards/wemos/lolin-s3.md) board satisfies all these criteria.
 
-## 433MHz radio & antenna
+## 433 MHz Transmitter
 
-See the [Radio](../hardware/radio/index.md) page for a quick one-stop shop.
+See the [Transmitter](../hardware/transmitter/index.md) page for a quick one-stop shop.
 
 ## Shockers
 
 See the [Shockers](../hardware/shockers/index.md) page for (yet another) one-stop shop.
-
 
 ## Assembly
 

--- a/docs/quickstart/what-you-need.md
+++ b/docs/quickstart/what-you-need.md
@@ -1,7 +1,7 @@
 
 # What you need
 
-If you've found yourself here, chances are you're either looking to get shocked, or shock a friend or partner! We've written this quickstart guide to help you get shocking as fast as possible.
+If you've found yourself here, chances are you're either looking to get shocked, or shock a friend or partner! We've written this quick start guide to help you get shocking as fast as possible.
 
 ## Requirements
 
@@ -11,14 +11,14 @@ To get started with OpenShocks, you need three things:
 
 This can be either a public or private OpenShock server. We recommend the [ShockLink.net](https://shocklink.net) public OpenShock instance.
 
-Interested in hosting your own? Check out [Selfhosting](../diy/selfhosting.md).
+Interested in hosting your own server? Check out the [Self-hosting](../diy/selfhosting.md) guide.
 
-### 2. An OpenShock Controller
+### 2. An OpenShock controller
 
-This is a fancy way of saying "a micro-controller and a 433MHz radio". It bridges the gap between shockers and the OpenShock server.
+A controller connects OpenShock to the shock device via a micro-controller and a 433 MHz transmitter.
 
-- For pre-builts, check out the [Hardware vendors](../vendors/hardware/index.md).
-- For building your own, after reading the [Buying guide](../quickstart/buying-guide.md), head over to our do-it-yourself [Assembly guide](../diy/assembling.md).
+- For pre-built options, check out the [Hardware vendors](../vendors/hardware/index.md).
+- For building your own, after reading the [Buying guide](../quickstart/buying-guide.md), head over to our do it yourself [Assembly guide](../diy/assembling.md).
 
 ### 3. Shockers
 

--- a/docs/vendors/hardware/index.md
+++ b/docs/vendors/hardware/index.md
@@ -17,7 +17,7 @@ This is a **non-curated list** of self-reported vendors from the OpenShock **com
 | Term | Meaning |
 |-|-|
 | :airplane: Ships to | The region(s) that a vendor ships to. |
-| :electric_plug: Controllers | Whether they sell pre-assembled controllers ([ESP32 board](../../hardware/boards/index.md) + [433MHz radio](../../hardware/radio/index.md)). |
+| :electric_plug: Controllers | Whether they sell pre-assembled controllers ([ESP32 board](../../hardware/boards/index.md) + [433 MHz transmitter](../../hardware/transmitter/index.md)). |
 | :high_voltage: Shockers | Whether they sell [shockers](../../hardware/shockers/index.md). |
 | :package: 3D Prints | Whether they sell 3D-printed cases (for controllers) or spacers (for shockers). |
 
@@ -37,4 +37,4 @@ This is a **non-curated list** of self-reported vendors from the OpenShock **com
 |-|-|-|-|-|-|
 | [nullstalgia](./nullstalgia.md) | :flag_us: USA | :white_check_mark: | :white_check_mark: | :white_check_mark: | 2023-12-01 |
 
-*Want to be on this list? Hit up a maintainer on [Discord](https://discord.gg/AHcCbXbEcF).*
+*Want to be on this list? Hit up a maintainer on [Discord](https://discord.gg/OpenShock).*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,8 +47,8 @@ nav:
                       - hardware/boards/wemos/d1-mini-esp32.md
                       - hardware/boards/wemos/lolin-s2-mini.md
                       - hardware/boards/wemos/lolin-s3.md
-          - Radio:
-                - hardware/radio/index.md
+          - Transmitter:
+                - hardware/transmitter/index.md
 
     - Vendors:
           - Hardware:


### PR DESCRIPTION
Currently inconsistent naming for 433 MHz transmitters fixed via this PR