### PR TITLE
Spelling fixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 
 # OpenShock
 
-Welcome to OpenShock! We're proud to present our fully open-source software solution, compatible with off the shelf hardware, to get you started in the world of shocking!
+Welcome to OpenShock! We're proud to present our fully open-source software solution, compatible with off-the-shelf hardware, to get you started in the world of shocking!
 
 ## Getting started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 
 # OpenShock
 
-Welcome to OpenShock! We're proud to present our fully open-source software solution, compatible with off the shelf hardware to get you started in the world of shocking!
+Welcome to OpenShock! We're proud to present our fully open-source software solution, compatible with off the shelf hardware, to get you started in the world of shocking!
 
 ## Getting started
 


### PR DESCRIPTION
Introductory statement! Main clause, intermediate clause, purpose clause!

Off the shelf should be 'off-the-shelf' because 'off the shelf' is a phrase, while 'off-the-shelf' is a noun, which is the usage in the text. It's also generally agreed that off-the-shelf is the proper spelling since the hyphen clarifies the relationship between the words.