### PR TITLE
Point to scalar for OpenAPI docs

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -15,7 +15,7 @@ tags:
 
 ## OpenAPI Documentation
 
-You can find the OpenAPI Documentation here: [api.OpenShock.app/swagger](https://api.openshock.app/swagger)
+You can find the OpenAPI Documentation here: [Definition Version 1](https://api.openshock.app/scalar/1), [Definition Version 2](https://api.openshock.app/scalar/2)
 
 Note that there is both a [Definition Version 1](https://api.openshock.app/swagger/1/swagger.json) and [Definition Version 2](https://api.openshock.app/swagger/2/swagger.json) file.
 


### PR DESCRIPTION
Hola, https://wiki.openshock.org/dev/ has a broken link to the OpenAPI documentation. Specifically https://api.openshock.app/swagger is not treated like a valid link by the API to the tune of 

```
{"type":"https://docs.api-versioning.org/problems#invalid","title":"Invalid API version","status":400,"detail":"The HTTP resource that matches the request URI 'https://api.openshock.app/swagger' does not support the API version 'swagger'.","traceId":"00-eb582085d32c4f5a1b1cc42ab2746b42-175b1ba35b792821-00"}
```

I asked on discord and was provided https://api.openshock.app/scalar/1 https://api.openshock.app/scalar/2 as links. Just submitting an edit so that other people can get there too. 


