### PR TITLE
fix: redirect to correct location in nginx

### DIFF
--- a/docs/guides/selfhosting/index.md
+++ b/docs/guides/selfhosting/index.md
@@ -381,7 +381,7 @@ In addition we also need a ssl certificate, change the path to your needs, and c
 
         # Redirect /s/<anything> to /#/public/proxy/shares/links/<anything>
         location ~ ^/s/(.*)$ {
-            return 301 /#/public/proxy/shares/link/$1;
+            return 301 /#/public/proxy/shares/links/$1;
         }
 
         # Redirect /c/<anything> to /#/public/proxy/shares/code/<anything>


### PR DESCRIPTION
This PR fixes a typo in the redirects for the self-hosting nginx configuration. This ensures the generated public share are working properly