### PR TITLE
Fix indentation on disclaimer so it renders correctly

### DIFF
--- a/docs/vendors/hardware/index.md
+++ b/docs/vendors/hardware/index.md
@@ -10,7 +10,7 @@ tags:
 This is a **non-curated list** of self-reported vendors from the OpenShock **community**.
 
 !!! warning "Disclaimer"
-The OpenShock team does not provide **any** guarantees about the quality of products or services rendered.
+    The OpenShock team does not provide **any** guarantees about the quality of products or services rendered.
 
 ## Explanation
 


### PR DESCRIPTION
I noticed while testing it locally but the index.md is missing some indentation
Before:
<img width="1094" height="136" alt="image" src="https://github.com/user-attachments/assets/92a9410c-4f34-4c8a-8888-fbf893980350" />
After:
<img width="1094" height="136" alt="image" src="https://github.com/user-attachments/assets/3d1f8fb6-a156-4b7d-af84-a3524ccfefc7" />
