### PR TITLE
Fix AliExpress links in caixianlin.md

### DIFF
--- a/docs/hardware/shockers/caixianlin.md
+++ b/docs/hardware/shockers/caixianlin.md
@@ -18,11 +18,11 @@ Cheap and easily acquirable.
 
 Best effort list of current AliExpress sellers. Feel free to add more sources to this list!
 
-- :globe_with_meridians: [AliExpress](https://aliexpress.com/item/1005005133046985.html)
+- :globe_with_meridians: [AliExpress](https://www.aliexpress.com/item/1005005133046985.html)
 - :globe_with_meridians: [AliExpress](https://www.aliexpress.com/item/3256804946732233.html)
 - :globe_with_meridians: [AliExpress](https://www.aliexpress.com/item/3256805637384984.html)
 - :globe_with_meridians: [AliExpress](https://www.aliexpress.com/item/3256806810698119.html)
-- :globe_with_meridians: [AliExpress](https://aliexpress.com/item/1005005823699736.html)
+- :globe_with_meridians: [AliExpress](https://www.aliexpress.com/item/1005005823699736.html)
 - :globe_with_meridians: [AliBaba](https://www.alibaba.com/product-detail/MZ-880-Waterproof-Rechargeable-Vibrating-Dog_1600152421803.html)
 
 ### Cables


### PR DESCRIPTION
This pull request makes a minor documentation update to the list of AliExpress sellers in the `docs/hardware/shockers/caixianlin.md` file. The change corrects the URLs for two AliExpress links to ensure they use the correct `www.aliexpress.com` domain.

- Documentation:
  * Fixed two AliExpress URLs to use the correct `www.aliexpress.com` domain in the sellers list in `caixianlin.md`.