### PR TITLE
Update Sillypupkit info at their request

### DIFF
--- a/docs/vendors/hardware/index.md
+++ b/docs/vendors/hardware/index.md
@@ -40,7 +40,7 @@ const vendors = [
   { name: "Yunadex", link: "./yunadex", from: "🇫🇮 Finland", ships_to: ["GLOBAL"], hubs: true, shockers: true, prints3d: true, design: "Custom", region: "EUROPE" },
   // NORTH_AMERICA
   { name: "Nullstalgia", link: "./nullstalgia", from: "🇺🇸 USA", ships_to: ["NA"], hubs: true, shockers: true, prints3d: true, design: "Official", region: "NORTH_AMERICA" },
-  { name: "Sillypupkit", link: "./sillypupkit", from: "❓ Unspecified", ships_to: ["GLOBAL"], hubs: true, shockers: true, prints3d: true, design: "Custom", region: "NORTH_AMERICA" },
+  { name: "Sillypupkit", link: "./sillypupkit", from: "🇨🇦 Canada", ships_to: ["GLOBAL"], hubs: true, shockers: true, prints3d: true, design: "Custom", region: "NORTH_AMERICA" },
   { name: "NamelessNanashi", link: "./namelessnanashi", from: "🇺🇸 USA", ships_to: ["NA"], hubs: true, shockers: false, prints3d: true, design: "Custom", region: "NORTH_AMERICA" },
   // AUSTRALIA
   { name: "Ebthing", link: "./ebthing", from: "🇦🇺 Australia", ships_to: ["OCEANIA"], hubs: true, shockers: true, prints3d: true, design: "Custom", region: "AUSTRALIA" }

--- a/docs/vendors/hardware/sillypupkit.md
+++ b/docs/vendors/hardware/sillypupkit.md
@@ -12,9 +12,8 @@ The OpenShock team does not provide **any** guarantees about the quality of prod
 
 Started `2024-09-07`.
 
-Selling Hubs and Shockers via discord and email inquiry.
+Selling Hubs and Shockers via discord.
 
 ## Contact
 
 - :simple-discord: Discord -- `sillypupkit`
-- :material-email: Email -- `pupkitprinting@proton.me`


### PR DESCRIPTION
This pull request updates the documentation for the `Sillypupkit` hardware vendor, clarifying their regional origin and simplifying their contact information. The most important changes are:

Vendor information updates:
* Changed the `from` field for `Sillypupkit` in `docs/vendors/hardware/index.md` from "Unspecified" to "🇨🇦 Canada", providing more accurate regional information.

Contact and sales details:
* Updated `docs/vendors/hardware/sillypupkit.md` to remove their email contact and specify that sales are only via Discord, streamlining the communication channels.