### PR TITLE
Update my vendor info to include info about my spacer design

### DIFF
--- a/docs/vendors/hardware/namelessnanashi.md
+++ b/docs/vendors/hardware/namelessnanashi.md
@@ -14,7 +14,7 @@ Started `2025-08-07`.
 
 Selling Hubs and Spacers via Discord or E-Mail inquiries.
 
-Current spacers sold are a custom modified design found at [NanashiTheNameless/OpenShock-Custom-Spacer](<https://github.com/NanashiTheNameless/OpenShock-Custom-Spacer>) licensed under GPL-3.0 same as the official designs.
+Current spacers sold are a custom modified design found at [NanashiTheNameless/OpenShock-Custom-Spacer](<https://github.com/NanashiTheNameless/OpenShock-Custom-Spacer>) licensed under GPL-3.0, the same as the official designs.
 
 Will also 3D print custom parts upon request.
 


### PR DESCRIPTION
This pull request updates the vendor documentation for NamelessNanashi to clarify the design and source of the spacers being sold, and to improve the description of custom 3D printing services.

Vendor documentation updates:

* Updated the description of spacers to specify that the current spacers sold are a custom modified design available at `NanashiTheNameless/OpenShock-Custom-Spacer` and licensed under GPL-3.0, aligning with the official designs.
* Improved the wording regarding 3D printing services to clarify that custom parts can be 3D printed upon request.