### PR TITLE
Add .md URL stripping redirects for legacy links

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,7 @@ const config = {
   // Prod redirects live in `public/_redirects` (Cloudflare Pages).
   ...(isDev && {
     redirects: async () => [
+      { source: '/:path*.md', destination: '/:path*', permanent: true },
       { source: '/', destination: '/home', permanent: false },
     ],
   }),

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,4 @@
+/legal/*.md        /home/legal/:splat  301
+/*.md               /:splat             301
 /                   /home/           301
 /legal/*            /home/legal/:splat  301


### PR DESCRIPTION
### Motivation

- Preserve compatibility with legacy markdown-style links by redirecting any incoming path that ends with `.md` to the same path without the extension so old links keep working.

### Description

- Add a dev-time Next.js redirect in `next.config.mjs` that permanently maps `/:path*.md` to `/:path*` so local/dev server behavior matches production.
- Add production redirect rules in `public/_redirects` to strip `.md` on Cloudflare Pages and include a specific `/legal/*.md` mapping to `/home/legal/:splat` while keeping existing root/legal rules.

### Testing

- Ran `pnpm lint` which passed with no warnings or errors. 
- Ran `pnpm build` which completed successfully and generated the static pages without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4b5d3c888327b36b0b1ccda35cd5)