### PR TITLE
(NamelessNanashi) Add notice for preferred communication via Discord over E-Mail

### DIFF
--- a/docs/vendors/hardware/namelessnanashi.mdx
+++ b/docs/vendors/hardware/namelessnanashi.mdx
@@ -23,6 +23,8 @@ Will also 3D print custom parts upon request.
 
 A list of reviews can be found in the [OpenShock Discord](https://discord.gg/OpenShock) under the [Vendor Reviews](https://discord.com/channels/1078124408775901204/1424434056652783616) section.
 
+**Discord is significantly preferred to E-Mail. If you have both as an option use Discord.**
+
 **Via Discord, please clarify that you are messaging about an OpenShock in your first message.**
 
 **Via E-Mail, please include `OpenShock` in the subject somewhere. It will cause your email to be automatically sorted into the correct category, making it easier for me to prioritize responses.**


### PR DESCRIPTION
This pull request adds a note to the vendor documentation for NamelessNanashi to clarify the preferred method of contact. Discord is now explicitly stated as the significantly preferred communication channel over email.

- Documentation update:
  * Added a clear note in `namelessnanashi.mdx` that Discord is significantly preferred over email for contacting the vendor.